### PR TITLE
Add first MPI test based on a Hello World example

### DIFF
--- a/vsc/config_vsc.py
+++ b/vsc/config_vsc.py
@@ -52,6 +52,15 @@ site_configuration = {
                     'max_jobs': 1,
                     'launcher': 'local',
                 },
+                {
+                    'name': 'mpi-job',
+                    'scheduler': 'slurm',
+                    'access': [],
+                    'environs': ['foss-2021a'],
+                    'descr': 'MPI jobs',
+                    'max_jobs': 1,
+                    'launcher': 'srun',
+                },
             ]
         },
         {
@@ -79,6 +88,19 @@ site_configuration = {
                     'descr': 'single-node jobs',
                     'max_jobs': 1,
                     'launcher': 'local',
+                },
+                {
+                    'name': 'mpi-job',
+                    'scheduler': 'slurm',
+                    'access': [],
+                    'environs': ['foss-2021a'],
+                    'descr': 'MPI jobs',
+                    'max_jobs': 1,
+                    # TODO Here we actually want to set vsc-mympirun, but since
+                    # this is a custom launcher not shipped with ReFrame, we
+                    # can only do this in the test itself after registering the
+                    # vsc-mympirun launcher
+                    'launcher': 'srun',
                 },
             ]
         },
@@ -108,11 +130,23 @@ site_configuration = {
                     'max_jobs': 1,
                     'launcher': 'local',
                 },
+                {
+                    'name': 'mpi-job',
+                    'scheduler': 'torque',
+                    'access': [kul_account_string_tier2],
+                    'environs': ['foss-2021a'],
+                    'descr': 'MPI jobs',
+                    'max_jobs': 1,
+                    'launcher': 'mpirun',
+                    'variables': [['MODULEPATH', '/apps/leuven/skylake/2021a/modules/all']],
+                },
             ]
         },
     ],
     'environments': [
         {'name': 'builtin', 'cc': 'gcc', 'cxx': 'g++', 'ftn': 'gfortran',},
+        {'name': 'foss-2021a', 'cc': 'mpicc', 'cxx': 'mpicxx',
+         'ftn': 'mpif90', 'modules': ['foss/2021a'],},
     ],
     'general': [
         {

--- a/vsc/prgenv/README.md
+++ b/vsc/prgenv/README.md
@@ -1,0 +1,18 @@
+# How to run the tests
+
+## MPI Hello World test
+
+The following has been tested on genius, hortense, and hydra
+
+```shell
+module load ReFrame
+cd vsc/progenv
+reframe --verbose --run --checkpath mpi_hello_world.py -C ../config_vsc.py
+```
+
+On Hortense, you first need to specify a credit account to which you have access
+
+```shell
+# specify Slurm account to use (credits)
+export SBATCH_ACCOUNT='gadminforever'
+```

--- a/vsc/prgenv/mpi_hello_world.py
+++ b/vsc/prgenv/mpi_hello_world.py
@@ -1,0 +1,57 @@
+import os
+import reframe as rfm
+import reframe.utility.sanity as sn
+from reframe.core.backends import register_launcher
+from reframe.core.launchers import JobLauncher
+from reframe.core.backends import getlauncher
+
+
+# TODO Ideally, this launcher would be included in the ReFrame repository. The
+# next best thing is probably to define it in a script in vsc-test-suite that
+# all tests can access.
+@register_launcher('vsc-mympirun')
+class MympirunLauncher(JobLauncher):
+    def command(self, job):
+        cmd = ['mympirun']
+        if job.num_tasks_per_node:
+            cmd += ['-h', str(job.num_tasks_per_node)]
+        return cmd
+
+
+@rfm.simple_test
+class MPIHelloWorldTest(rfm.RegressionTest):
+    descr = '''Compile and execute a simple Hello World MPI example. A job is
+    launched on 2 nodes with 3 MPI processes per node. It is checked that each
+    process prints a Hello World line and that indeed two nodes were used.'''
+    valid_systems = ['*:mpi-job']
+    valid_prog_environs = ['foss-2021a']
+    maintainers = ['stevenvdb']
+    time_limit = '10m'
+    num_tasks = 6
+    num_tasks_per_node = 3
+    num_cpus_per_task = 1
+    executable = 'mpi_hello_world'
+    sourcesdir = 'src_mpi_hello_world'
+
+    @run_before('run')
+    def set_launcher_to_mympirun(self):
+        if self.current_system.name in ['hortense',]:
+            self.modules += ['vsc-mympirun']
+            self.job.launcher = getlauncher('vsc-mympirun')()
+
+    @sanity_function
+    def assert_number_of_hellos(self):
+        # Check that the number of "Hello world" print statements equals the
+        # total number of processes'''
+        num_hellos = sn.len(sn.findall(r'^Hello world', self.stdout))
+        num_hellos_ok = sn.assert_eq(num_hellos, self.num_tasks)
+
+        # Check that the number of different hosts that printed "Hello world"
+        # equals the number of nodes. The output contains lines like this:
+        # Hello world from processor r25i27n07, rank 1 out of 6 processors
+        # The regular expression extracts the part between processor and ,
+        regex = r'^Hello world from processor (?P<node>\S+), rank'
+        num_nodes = sn.count_uniq(sn.extractall(regex, self.stdout, 'node', str))
+        num_nodes_ok = sn.assert_eq(num_nodes, self.num_tasks //
+                                               self.num_tasks_per_node)
+        return sn.assert_true(sn.and_(num_hellos_ok, num_nodes_ok))

--- a/vsc/prgenv/src_mpi_hello_world/Makefile
+++ b/vsc/prgenv/src_mpi_hello_world/Makefile
@@ -1,0 +1,10 @@
+EXECS=mpi_hello_world
+MPICC?=mpicc
+
+all: ${EXECS}
+
+mpi_hello_world: mpi_hello_world.c
+	${MPICC} -o mpi_hello_world mpi_hello_world.c
+
+clean:
+	rm ${EXECS}

--- a/vsc/prgenv/src_mpi_hello_world/mpi_hello_world.c
+++ b/vsc/prgenv/src_mpi_hello_world/mpi_hello_world.c
@@ -1,0 +1,29 @@
+// Copied from https://mpitutorial.com/tutorials/mpi-hello-world/
+
+#include <mpi.h>
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+    // Initialize the MPI environment
+    MPI_Init(NULL, NULL);
+
+    // Get the number of processes
+    int world_size;
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+    // Get the rank of the process
+    int world_rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+
+    // Get the name of the processor
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int name_len;
+    MPI_Get_processor_name(processor_name, &name_len);
+
+    // Print off a hello world message
+    printf("Hello world from processor %s, rank %d out of %d processors\n",
+           processor_name, world_rank, world_size);
+
+    // Finalize the MPI environment.
+    MPI_Finalize();
+}


### PR DESCRIPTION
This PR adds a first MPI test; a job is launched on multiple (2) nodes with multiple (3) MPI processes per node. Every MPI process prints its rank and hostname where it is running. This allows to check that the correct number of MPI processes were launched and that they are indeed running on different hosts.

One of my goals was to keep the test script itself agnostic about VSC site details. This worked out pretty well, the test works both on hydra and genius by just setting the `launcher` in the configuration file to `srun` and `mpirun` respectively. Using `mympirun` on hortense is a bit more involved, as you need to define a custom launcher and set it explicitly in the test script. This is something that needs some improvement.

I added one environment to the configuration file (which as far as I understand roughly translates to an EB toolchain): foss-2021a. Probably we will need more in the future, but this is not crucial at the moment I think.

I deviated slightly from the existing `VSCEnvTest` and `VSCJobTest` tests: I don't see the point of defining `valid_systems` and `valid_program_environs` as environment variables instead of setting them in the test script.

For the directory structure, I followed https://github.com/eth-cscs/reframe/tree/master/cscs-checks and put the MPI Hello World test in prgenv