### PR TITLE
Availability and mode tests for shared filesystems.

### DIFF
--- a/tests/cue/readme.md
+++ b/tests/cue/readme.md
@@ -16,3 +16,5 @@ Each entry of the document is structured as follows:
     * `modname`: load the specified module before executing the test. Packages requiring a module load in certain sites and are installed at system level in others can be handled by greedly adding the required module in this field. 
 
 ## env.py
+
+## shared_fs.py

--- a/tests/cue/readme.md
+++ b/tests/cue/readme.md
@@ -18,3 +18,12 @@ Each entry of the document is structured as follows:
 ## env.py
 
 ## shared_fs.py
+
+This file contains tests which check the availability and mode of the shared file system and availability of account directories. 
+
+To add an extra directory to test, edit the json `./src/shared_fs_list.py`.
+Each entry of the document is structured as follows:
+* mandatory entry
+    * `mount`: the mount point/directory undergoing testing
+* optional entry
+    * `envar`: environment variable associated with the directory

--- a/tests/cue/shared_fs.py
+++ b/tests/cue/shared_fs.py
@@ -1,0 +1,62 @@
+import os
+import reframe as rfm
+import reframe.utility.sanity as sn
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+from shared_fs_list import shared_fs
+
+
+@rfm.simple_test
+class VSCSharedFSMountTest(rfm.RunOnlyRegressionTest):
+    descr = "test shared filesystem mount "
+    fs = parameter(shared_fs)
+    valid_systems = ["*:local", "*:single-node"]
+    valid_prog_environs = ["builtin"]
+    maintainers = ['rverschoren']
+    time_limit = '10m'
+    num_tasks = 1
+    num_tasks_per_node = 1
+    num_cpus_per_task = 1
+    tags = {"antwerp"}
+
+    @run_after('init')
+    def set_param(self):
+        self.descr += self.fs['mount']
+        exe = self.fs.get('exe')
+        if not exe:
+            # default: check if directory is a mount point
+            exe = """python3 -c 'import os;print(os.path.ismount(os.path.realpath("{}")))'"""
+        self.executable = exe.format(self.fs['mount'])
+
+    @sanity_function
+    def assert_env(self):
+        return sn.assert_found(r'^True$', self.stdout)
+
+
+@rfm.simple_test
+class VSCSharedFSMode(rfm.RunOnlyRegressionTest):
+    descr = "test shared filesystem mode "
+    fs = parameter(shared_fs)
+    valid_systems = ["*:local", "*:single-node"]
+    valid_prog_environs = ["builtin"]
+    maintainers = ['rverschoren']
+    time_limit = '10m'
+    num_tasks = 1
+    num_tasks_per_node = 1
+    num_cpus_per_task = 1
+    tags = {"antwerp"}
+
+    @run_after('init')
+    def set_param(self):
+        self.descr += self.fs['mount']
+        mode = self.fs.get('mode')
+        if not mode:
+            # default: check if directory has rwxr-xr-x permissions 
+            mode = '755'
+        exe = """python3 -c 'import os;print(oct(os.stat(os.path.realpath("{}")).st_mode)[-3:] == "{}")'"""
+        self.executable = exe.format(self.fs['mount'], mode)
+
+    @sanity_function
+    def assert_env(self):
+        return sn.assert_found(r'^True$', self.stdout)

--- a/tests/cue/shared_fs.py
+++ b/tests/cue/shared_fs.py
@@ -4,13 +4,14 @@ import reframe.utility.sanity as sn
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
-from shared_fs_list import shared_fs
+from shared_fs_list import shared_fs, shared_fs_sites
 
 
 @rfm.simple_test
 class VSCSharedFSMountTest(rfm.RunOnlyRegressionTest):
-    descr = "test shared filesystem mount "
+    descr = "test shared filesystem mount point "
     fs = parameter(shared_fs)
+    site = parameter(shared_fs_sites)
     valid_systems = ["*:local", "*:single-node"]
     valid_prog_environs = ["builtin"]
     maintainers = ['rverschoren']
@@ -22,12 +23,10 @@ class VSCSharedFSMountTest(rfm.RunOnlyRegressionTest):
 
     @run_after('init')
     def set_param(self):
-        self.descr += self.fs['mount']
-        exe = self.fs.get('exe')
-        if not exe:
-            # default: check if directory is a mount point
-            exe = """python3 -c 'import os;print(os.path.ismount(os.path.realpath("{}")))'"""
-        self.executable = exe.format(self.fs['mount'])
+        path = os.path.join(self.fs['mount'], self.site)
+        self.descr += path
+        exe = """python3 -c 'import os;print(os.path.isdir(os.path.realpath("{}")))'"""
+        self.executable = exe.format(path)
 
     @sanity_function
     def assert_env(self):
@@ -38,6 +37,7 @@ class VSCSharedFSMountTest(rfm.RunOnlyRegressionTest):
 class VSCSharedFSMode(rfm.RunOnlyRegressionTest):
     descr = "test shared filesystem mode "
     fs = parameter(shared_fs)
+    site = parameter(shared_fs_sites)
     valid_systems = ["*:local", "*:single-node"]
     valid_prog_environs = ["builtin"]
     maintainers = ['rverschoren']
@@ -49,13 +49,44 @@ class VSCSharedFSMode(rfm.RunOnlyRegressionTest):
 
     @run_after('init')
     def set_param(self):
-        self.descr += self.fs['mount']
+        path = os.path.join(self.fs['mount'], self.site)
+        self.descr += path
         mode = self.fs.get('mode')
         if not mode:
             # default: check if directory has rwxr-xr-x permissions 
             mode = '755'
         exe = """python3 -c 'import os;print(oct(os.stat(os.path.realpath("{}")).st_mode)[-3:] == "{}")'"""
-        self.executable = exe.format(self.fs['mount'], mode)
+        self.executable = exe.format(path, mode)
+
+    @sanity_function
+    def assert_env(self):
+        return sn.assert_found(r'^True$', self.stdout)
+
+
+@rfm.simple_test
+class VSCSharedFSAccountDir(rfm.RunOnlyRegressionTest):
+    descr = "test account directory "
+    fs = parameter(shared_fs)
+    valid_systems = ["*:local", "*:single-node"]
+    valid_prog_environs = ["builtin"]
+    maintainers = ['rverschoren']
+    time_limit = '10m'
+    num_tasks = 1
+    num_tasks_per_node = 1
+    num_cpus_per_task = 1
+    tags = {"antwerp"}
+
+    @run_after('init')
+    def set_param(self):
+        self.descr += self.fs['mount'] + " " + self.fs['envar'] + " " + os.environ['USER']
+        path = os.environ[self.fs['envar']]
+        if not path:
+            # Order is important for indexing
+            sites = ['brussel', 'antwerpen', 'leuven', 'gent']
+            account_site = sites[int(os.environ['USER'][3])-1]
+            path = os.path.join(self.fs['mount'], account_site, os.environ['USER'][3:6], os.environ['USER'])
+        exe = """python3 -c 'import os;print(os.path.isdir(os.path.realpath("{}")))'"""
+        self.executable = exe.format(path)
 
     @sanity_function
     def assert_env(self):

--- a/tests/cue/shared_fs.py
+++ b/tests/cue/shared_fs.py
@@ -81,9 +81,8 @@ class VSCSharedFSAccountDir(rfm.RunOnlyRegressionTest):
         self.descr += self.fs['mount'] + " " + self.fs['envar'] + " " + os.environ['USER']
         path = os.environ[self.fs['envar']]
         if not path:
-            # Order is important for indexing
-            sites = ['brussel', 'antwerpen', 'leuven', 'gent']
-            account_site = sites[int(os.environ['USER'][3])-1]
+            sites = {'1': "brussel", '2': "antwerpen", '3': "leuven", '4': "gent"}
+            account_site = sites[os.environ["USER"][3]]
             path = os.path.join(self.fs['mount'], account_site, os.environ['USER'][3:6], os.environ['USER'])
         exe = """python3 -c 'import os;print(os.path.isdir(os.path.realpath("{}")))'"""
         self.executable = exe.format(path)

--- a/tests/cue/src/shared_fs_list.py
+++ b/tests/cue/src/shared_fs_list.py
@@ -1,0 +1,29 @@
+shared_fs = [
+    {
+        'mount': '/data/antwerpen',
+    },
+    {
+        'mount': '/data/brussel',
+    },
+    {
+        'mount': '/data/gent',
+    },
+    {
+        'mount': '/data/leuven',
+    },
+    {
+        'mount': '/user/antwerpen',
+    },
+    {
+        'mount': '/user/brussel',
+    },
+    {
+        'mount': '/user/gent',
+    },
+    {
+        'mount': '/user/leuven',
+    },
+    {
+        'mount': '/scratch',
+    },
+]

--- a/tests/cue/src/shared_fs_list.py
+++ b/tests/cue/src/shared_fs_list.py
@@ -1,29 +1,16 @@
+shared_fs_sites = ['antwerpen', 'brussel', 'gent', 'leuven']
+
 shared_fs = [
     {
-        'mount': '/data/antwerpen',
+        'mount': '/data',
+        'envar': 'VSC_DATA',
     },
     {
-        'mount': '/data/brussel',
-    },
-    {
-        'mount': '/data/gent',
-    },
-    {
-        'mount': '/data/leuven',
-    },
-    {
-        'mount': '/user/antwerpen',
-    },
-    {
-        'mount': '/user/brussel',
-    },
-    {
-        'mount': '/user/gent',
-    },
-    {
-        'mount': '/user/leuven',
+        'mount': '/user',
+        'envar': 'VSC_HOME',
     },
     {
         'mount': '/scratch',
+        'envar': 'VSC_SCRATCH',
     },
 ]


### PR DESCRIPTION
These are some preliminary tests for the shared filesystems (/data, /user, /scratch).

The reliance on environment variables in _tests/cue/src/shared_fs_list.py_ is admittedly a bit clunky. However, it avoids specifying the complete path for each site separately, as that may differ for each site and user (primarily looking at VSC_SCRATCH).

