### PR TITLE
Change the credit account necessary to run jobs on Leuven Tier-2 cluster

### DIFF
--- a/config_vsc.py
+++ b/config_vsc.py
@@ -20,9 +20,9 @@ perf_logging_format = 'reframe: ' + '|'.join(
     ]
 )
 
-# To run jobs on the kul cluster, you need to have access to following credit
-# account (currently only the case for kul admins)
-kul_account_string_tier2 = '-A lpt2_sysadmin'
+# To run jobs on the kul cluster, you need to be a member of the following
+# vsc group
+kul_account_string_tier2 = '-A lpt2_vsc_test_suite'
 
 site_configuration = {
     'systems': [


### PR DESCRIPTION
I created a group on the VSC account page called lpt2_vsc_test_suite and invited people that contributed to this repository. Once you are member of this group, you should be able to run jobs on our Genius cluster.