### PR TITLE
Fs update

### DIFF
--- a/tests/cue/shared_fs.py
+++ b/tests/cue/shared_fs.py
@@ -66,7 +66,11 @@ class VSCSharedFSMode(rfm.RunOnlyRegressionTest):
 @rfm.simple_test
 class VSCSharedFSAccountDir(rfm.RunOnlyRegressionTest):
     descr = "test account directory "
-    fs = parameter(shared_fs.keys())
+    targets = []
+    for x in shared_fs.keys():
+        if 'envar' in shared_fs[x].keys():
+            targets += [x]
+    fs = parameter(targets)
     valid_systems = ["*:local", "*:single-node"]
     valid_prog_environs = ["builtin"]
     maintainers = ['rverschoren']

--- a/tests/cue/shared_fs.py
+++ b/tests/cue/shared_fs.py
@@ -45,7 +45,7 @@ class VSCSharedFSMode(rfm.RunOnlyRegressionTest):
     num_tasks = 1
     num_tasks_per_node = 1
     num_cpus_per_task = 1
-    tags = {"vsc", "cue"}
+    tags = {"vsc", "cue", "fs"}
 
     @run_after('init')
     def set_param(self):
@@ -74,7 +74,7 @@ class VSCSharedFSAccountDir(rfm.RunOnlyRegressionTest):
     num_tasks = 1
     num_tasks_per_node = 1
     num_cpus_per_task = 1
-    tags = {"vsc", "cue"}
+    tags = {"vsc", "cue", "fs"}
 
     @run_after('init')
     def set_param(self):

--- a/tests/cue/src/shared_fs_list.py
+++ b/tests/cue/src/shared_fs_list.py
@@ -11,9 +11,8 @@ shared_fs = {
         'mount': '/user',
         'envar': 'VSC_HOME',
     },
-    'VSC_SCRATCH':
+    'APPS':
     {
-        'mount': '/scratch',
-        'envar': 'VSC_SCRATCH',
-    },
+        'mount': '/apps',
+    }
 }


### PR DESCRIPTION
Removed scratch folder test from the Shared FS test file because is site specific.

Added check for `/apps/VSCsite` folders because site agnostic.

Works on all the sites.

Some tests fail in Hortense and Hydra, check required by site admins.