### PR TITLE
Add rocky8 as allowed value for VSC_OS_LOCAL

### DIFF
--- a/tests/cue/src/envars_list.py
+++ b/tests/cue/src/envars_list.py
@@ -44,7 +44,7 @@ envars = {
     },
     'VSC_OS_LOCAL':
     {
-        'exe': ['print(os.environ["VSC_OS_LOCAL"] in ["CO7", "RHEL8", "centos8", "centos7"])'],
+        'exe': ['print(os.environ["VSC_OS_LOCAL"] in ["CO7", "RHEL8", "centos8", "centos7", "rocky8"])'],
     },
     'VSC_SCRATCH_NODE':
     {


### PR DESCRIPTION
The new KU Leuven cluster runs on Rocky Linux, so we should allow `VSC_OS_LOCAL=rocky8`.